### PR TITLE
Simple MQTT implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,9 +399,12 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -727,6 +739,17 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -1087,10 +1110,10 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.0",
  "tower-service",
 ]
 
@@ -1810,9 +1833,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.25.0",
+]
+
+[[package]]
 name = "rust-cloudflare-dynamic-public-ip"
 version = "0.1.2"
 dependencies = [
+ "bincode",
+ "bytes",
  "chrono",
  "clap",
  "colored",
@@ -1821,6 +1864,7 @@ dependencies = [
  "log",
  "public-ip",
  "reqwest",
+ "rumqttc",
  "serde",
  "serde_json",
  "tokio",
@@ -1847,6 +1891,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
@@ -1856,6 +1914,19 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2065,6 +2136,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "string_cache"
@@ -2277,11 +2351,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls",
+ "rustls 0.23.12",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.2"
 edition = "2021"
 
 [dependencies]
+bincode = "1.3.3"
+bytes = { version = "1.7.2", features = ["serde"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.16", features = ["derive"] }
 colored = "2.1.0"
@@ -12,6 +14,7 @@ dotenvy = "0.15.7"
 log = "0.4.22"
 public-ip = "0.2.2"
 reqwest = { version = "0.12.7", features = ["json"] }
+rumqttc = "0.24.0"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 tokio = { version = "1.39.3", features = ["full"] }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -3,9 +3,12 @@ use std::{net::Ipv4Addr, sync::mpsc};
 use clap::Args;
 use log::{debug, error, info, trace, warn};
 
-use crate::cloudflare::{
-    client::CloudFlareClient,
-    models::{CloudFlareClientError, UpdateDNSRecordRequest},
+use crate::{
+    cloudflare::{
+        client::CloudFlareClient,
+        models::{CloudFlareClientError, UpdateDNSRecordRequest},
+    },
+    mqtt::{IpChangeMessage, MqttClient},
 };
 
 #[derive(Debug, Args)]
@@ -79,12 +82,30 @@ pub struct MonitorArguments {
 }
 
 pub async fn monitor_command(args: &MonitorArguments) -> i32 {
-    let cloudflare_token = std::env::var("CLOUDFLARE_TOKEN")
-        .expect("Environment variable CLOUDFLARE_TOKEN is not set");
-    let cloudflare_zone_id = std::env::var("CLOUDFLARE_ZONE_ID")
-        .expect("Environment variable CLOUDFLARE_ZONE_ID is not set");
+    let mqtt_client = build_mqtt_client().await;
 
-    let cloudflare_client = CloudFlareClient::new(&cloudflare_token, &cloudflare_zone_id);
+    // testing the mqtt publishing, REMOVE ME
+    if let Some(ref mqtt_client) = mqtt_client {
+        match mqtt_client
+            .publish_ip_change(IpChangeMessage {
+                old: Ipv4Addr::new(0, 0, 0, 0),
+                new: Ipv4Addr::new(127, 0, 0, 1),
+            })
+            .await
+        {
+            Ok(_) => {
+                println!("publish succesful!");
+            }
+            Err(e) => {
+                println!("failed to publish");
+                println!("{:?}", e);
+            }
+        }
+    }
+
+    return 0;
+
+    let cloudflare_client = build_cloudflare_client();
 
     let monitor_loop = MonitorLoop::new(std::time::Duration::from_secs(args.check_delay));
 
@@ -93,24 +114,7 @@ pub async fn monitor_command(args: &MonitorArguments) -> i32 {
     for message in monitor_loop.listen() {
         match message {
             MonitorLoopMessage::IpChanged { old_ip, new_ip } => {
-                info!("IP address change detected from {} to {}", old_ip, new_ip);
-
-                loop {
-                    match update_ip(&cloudflare_client, old_ip, new_ip).await {
-                        Ok(_) => {
-                            info!("Successfully updated IP to {}", new_ip);
-                            break;
-                        }
-                        Err(e) => {
-                            error!("Failed to update IP: {:?}", e);
-
-                            let delay = std::time::Duration::from_secs(120);
-                            warn!("Retrying in {:?}", delay);
-
-                            tokio::time::sleep(delay).await;
-                        }
-                    }
-                }
+                handle_update_ip_message(old_ip, new_ip, &mqtt_client, &cloudflare_client).await
             }
             MonitorLoopMessage::CouldNotGetIp => warn!("Could not get public IP"),
             MonitorLoopMessage::NoChange => trace!("No IP change"),
@@ -118,6 +122,78 @@ pub async fn monitor_command(args: &MonitorArguments) -> i32 {
     }
 
     0
+}
+
+fn build_cloudflare_client() -> CloudFlareClient {
+    trace!("Building CloudFlareClient");
+    let cloudflare_token = std::env::var("CLOUDFLARE_TOKEN")
+        .expect("Environment variable CLOUDFLARE_TOKEN is not set");
+    let cloudflare_zone_id = std::env::var("CLOUDFLARE_ZONE_ID")
+        .expect("Environment variable CLOUDFLARE_ZONE_ID is not set");
+
+    CloudFlareClient::new(&cloudflare_token, &cloudflare_zone_id)
+}
+
+async fn build_mqtt_client() -> Option<MqttClient> {
+    let enabled: bool = std::env::var("MQTT_ENABLED")
+        .unwrap_or(String::from("false"))
+        .parse()
+        .expect("Environment variable MQTT_ENABLED must be a boolean");
+
+    if !enabled {
+        debug!("MQTT is disabled");
+        return None;
+    }
+
+    debug!("MQTT is enabled");
+
+    trace!("Building MqttClient");
+
+    let mqtt_host = std::env::var("MQTT_HOST").expect("Environment variable MQTT_HOST is not set");
+    let mqtt_port: u16 = std::env::var("MQTT_PORT")
+        .unwrap_or(String::from("1883"))
+        .parse()
+        .expect("Environment variable MQTT_PORT must be a valid number");
+    let mqtt_id = std::env::var("MQTT_ID").unwrap_or(String::from("cfdpip"));
+    let mqtt_base_topic = std::env::var("MQTT_BASE_TOPIC").unwrap_or(String::from("cfdpip"));
+
+    Some(MqttClient::new(&mqtt_host, mqtt_port, &mqtt_id, &mqtt_base_topic).await)
+}
+
+async fn handle_update_ip_message(
+    old_ip: Ipv4Addr,
+    new_ip: Ipv4Addr,
+    mqtt_client: &Option<MqttClient>,
+    cloudflare_client: &CloudFlareClient,
+) {
+    info!("IP address change detected from {} to {}", old_ip, new_ip);
+
+    if let Some(ref mqtt_client) = mqtt_client {
+        mqtt_client
+            .publish_ip_change(IpChangeMessage {
+                old: old_ip,
+                new: new_ip,
+            })
+            .await
+            .unwrap();
+    }
+
+    loop {
+        match update_ip(&cloudflare_client, old_ip, new_ip).await {
+            Ok(_) => {
+                info!("Successfully updated IP to {}", new_ip);
+                break;
+            }
+            Err(e) => {
+                error!("Failed to update IP: {:?}", e);
+
+                let delay = std::time::Duration::from_secs(120);
+                warn!("Retrying in {:?}", delay);
+
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
 }
 
 async fn update_ip(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod cloudflare;
 mod logger;
+mod mqtt;
 
 use logger::LOGGER;
 

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -1,0 +1,77 @@
+#![allow(dead_code)]
+
+use std::net::Ipv4Addr;
+
+use bincode::ErrorKind;
+use bytes::Bytes;
+use log::debug;
+use rumqttc::v5::mqttbytes::QoS;
+use rumqttc::v5::{AsyncClient, ClientError, MqttOptions};
+use rumqttc::NetworkOptions;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use std::thread;
+use tokio::task;
+
+pub struct MqttClient {
+    client: AsyncClient,
+    base_topic: String,
+}
+
+impl MqttClient {
+    pub async fn new(host: &str, port: u16, id: &str, base_topic: &str) -> Self {
+        let mut mqttoptions = MqttOptions::new(id, host, port);
+        mqttoptions.set_keep_alive(std::time::Duration::from_secs(5));
+
+        let (client, mut _eventloop) = AsyncClient::new(mqttoptions, 10);
+
+        // todo: configure the base topic name
+        // todo: configure the authentication
+
+        Self {
+            client,
+            base_topic: String::from(base_topic),
+        }
+    }
+
+    pub async fn publish_ip_change(&self, payload: IpChangeMessage) -> Result<(), ClientError> {
+        let topic = format!("{}/ipchange", self.base_topic);
+        debug!("MQTT publishing to {}", topic);
+        self.client
+            .publish(&topic, QoS::ExactlyOnce, false, payload)
+            .await
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct IpChangeMessage {
+    pub old: Ipv4Addr,
+    pub new: Ipv4Addr,
+}
+
+// impl From<&IpChangeMessage> for Vec<u8> {
+//     fn from(value: &IpChangeMessage) -> Self {
+//         bincode::serialize(value).unwrap()
+//     }
+// }
+
+// impl From<IpChangeMessage> for Vec<u8> {
+//     fn from(value: IpChangeMessage) -> Self {
+//         bincode::serialize(&value).unwrap()
+//     }
+// }
+
+// impl TryFrom<&[u8]> for IpChangeMessage {
+//     type Error = Box<ErrorKind>;
+
+//     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+//         bincode::deserialize(value)
+//     }
+// }
+
+impl Into<Bytes> for IpChangeMessage {
+    fn into(self) -> Bytes {
+        let json = serde_json::to_vec(&self).expect("Failed to serialize IpChangeMessage to JSON");
+        Bytes::from(json)
+    }
+}

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -1,16 +1,11 @@
-#![allow(dead_code)]
-
 use std::net::Ipv4Addr;
 
 use bincode::ErrorKind;
 use bytes::Bytes;
-use log::debug;
-use rumqttc::v5::mqttbytes::QoS;
-use rumqttc::v5::{AsyncClient, ClientError, MqttOptions};
-use rumqttc::NetworkOptions;
+use log::{debug, error, trace};
+use rumqttc::{AsyncClient, ClientError, MqttOptions, QoS};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
-use std::thread;
 use tokio::task;
 
 pub struct MqttClient {
@@ -21,11 +16,28 @@ pub struct MqttClient {
 impl MqttClient {
     pub async fn new(host: &str, port: u16, id: &str, base_topic: &str) -> Self {
         let mut mqttoptions = MqttOptions::new(id, host, port);
-        mqttoptions.set_keep_alive(std::time::Duration::from_secs(5));
+        mqttoptions
+            .set_keep_alive(std::time::Duration::from_secs(60))
+            .set_clean_session(true);
 
-        let (client, mut _eventloop) = AsyncClient::new(mqttoptions, 10);
+        let (client, mut eventloop) = AsyncClient::new(mqttoptions.clone(), 10);
 
-        // todo: configure the base topic name
+        debug!("MQTT options: {:?}", mqttoptions);
+
+        task::spawn(async move {
+            trace!("Starting MQTT event loop");
+            loop {
+                match eventloop.poll().await {
+                    Ok(v) => {
+                        trace!("MQTT Event = {v:?}");
+                    }
+                    Err(e) => {
+                        error!("MQTT Event Error = {e:?}");
+                    }
+                }
+            }
+        });
+
         // todo: configure the authentication
 
         Self {
@@ -37,8 +49,11 @@ impl MqttClient {
     pub async fn publish_ip_change(&self, payload: IpChangeMessage) -> Result<(), ClientError> {
         let topic = format!("{}/ipchange", self.base_topic);
         debug!("MQTT publishing to {}", topic);
+
+        let payload: Bytes = payload.into();
+
         self.client
-            .publish(&topic, QoS::ExactlyOnce, false, payload)
+            .publish(&topic, QoS::AtLeastOnce, false, payload)
             .await
     }
 }
@@ -49,29 +64,29 @@ pub struct IpChangeMessage {
     pub new: Ipv4Addr,
 }
 
-// impl From<&IpChangeMessage> for Vec<u8> {
-//     fn from(value: &IpChangeMessage) -> Self {
-//         bincode::serialize(value).unwrap()
-//     }
-// }
+impl From<&IpChangeMessage> for Vec<u8> {
+    fn from(value: &IpChangeMessage) -> Self {
+        bincode::serialize(value).unwrap()
+    }
+}
 
-// impl From<IpChangeMessage> for Vec<u8> {
-//     fn from(value: IpChangeMessage) -> Self {
-//         bincode::serialize(&value).unwrap()
-//     }
-// }
+impl From<IpChangeMessage> for Vec<u8> {
+    fn from(value: IpChangeMessage) -> Self {
+        bincode::serialize(&value).unwrap()
+    }
+}
 
-// impl TryFrom<&[u8]> for IpChangeMessage {
-//     type Error = Box<ErrorKind>;
+impl TryFrom<&[u8]> for IpChangeMessage {
+    type Error = Box<ErrorKind>;
 
-//     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-//         bincode::deserialize(value)
-//     }
-// }
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        bincode::deserialize(value)
+    }
+}
 
-impl Into<Bytes> for IpChangeMessage {
-    fn into(self) -> Bytes {
-        let json = serde_json::to_vec(&self).expect("Failed to serialize IpChangeMessage to JSON");
+impl From<IpChangeMessage> for Bytes {
+    fn from(value: IpChangeMessage) -> Bytes {
+        let json = serde_json::to_vec(&value).expect("Failed to serialize IpChangeMessage");
         Bytes::from(json)
     }
 }

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -53,7 +53,7 @@ impl MqttClient {
         let payload: Bytes = payload.into();
 
         self.client
-            .publish(&topic, QoS::AtLeastOnce, false, payload)
+            .publish(&topic, QoS::AtLeastOnce, true, payload)
             .await
     }
 }


### PR DESCRIPTION
MQTT support to send a message when the public IP changes

# Changes
- Simple support for MQTT
- Added environment variable `MQTT_ENABLED`, `MQTT_HOST`, `MQTT_PORT`, `MQTT_ID` and `MQTT_BASE_TOPIC`
- Added dependencies bincode, bytes, and rumqttc

Authentication and certification isn't implemented yet.